### PR TITLE
Fix issues when doing regression task

### DIFF
--- a/horseshoe_bnn/models.py
+++ b/horseshoe_bnn/models.py
@@ -275,7 +275,7 @@ class GaussianBNN(nn.Module, Model):
                     mse += F.mse_loss(mean_output, target, reduction='sum')
                     mae += F.l1_loss(mean_output, target, reduction='sum')
 
-                    distributions = [SampleDistribution(ensemble_outputs.cpu().detach().numpy()[i], var_noise)
+                    distributions = [SampleDistribution(ensemble_outputs[i], var_noise)
                                         for i in range(test_batch_size)]
 
                 all_predicted_distributions.extend(distributions)


### PR DESCRIPTION
for boston dataset and regression tasks, this variable (`ensemble_outputs`) is already a numpy array, so the original code treat it as a Tensor and will throw an exception. Fixing this by treating it as numpy.